### PR TITLE
Fix atom beta build on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+language: generic
+dist: trusty
+
 notifications:
   email:
     on_success: never


### PR DESCRIPTION
Switching to `trusty` should include a new version of `libc`.